### PR TITLE
Add required param to cli helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ async function enumerateFeatures() {
 			cwd: cli.cwd,
 			eventBroadcaster,
 			featurePaths,
+			order: 'defined',
 			pickleFilter
 		});
 		const features = new Set(testCases.map(t => t.uri));


### PR DESCRIPTION
Cucumber-js 4.2.0 broke compatibility with cuke-skywalker.  
https://github.com/cucumber/cucumber-js/commit/563076cf078ec4719d6e7f83c35b3dc82ebbfb19  
There is a new option to specify random order for features. This created a new required `order` parameter for the `getTestCasesFromFilesystem` cli/helpers function.  
  
Currently, using cuke-skywalker with cucumber-js 4.2.0 or higher throws error `TypeError: Cannot read property 'split' of undefined`
  
Adding in this param allows cuke-skywalker to work with cucumber-js 4.2.0 and above. Could you please review and see if this is an acceptable way to fix?