### PR TITLE
Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Options
 
 Options are passed as environment variables.
 
-| Variable                       | Default                         | Description |
-| ------------------------------ | ----------                      | ----------- |
-| CUCUMBER_PARALLEL_WORKERS      | 4                               | Number of worker processes to distribute features to |
-| CUCUMBER_PARALLEL_REPORT_DIR   | ./reports                       | Output directory for worker output JSON files |
-| CUCUMBER_PARALLEL_DISTRIBUTION | roundrobin                      | Method for distributing features (roundrobin or uniform) |
-| CUCUMBER_JS_PATH               | ./node_modules/.bin/cucumber-js | Path to the cucumber-js bin |
+| Variable                       | Default                       | Description |
+| ------------------------------ | ----------                    | ----------- |
+| CUCUMBER_PARALLEL_WORKERS      | 4                             | Number of worker processes to distribute features to |
+| CUCUMBER_PARALLEL_REPORT_DIR   | reports                       | Output directory for worker output JSON files |
+| CUCUMBER_PARALLEL_DISTRIBUTION | roundrobin                    | Method for distributing features (roundrobin or uniform) |
+| CUCUMBER_JS_PATH               | node_modules/.bin/cucumber-js | Path to the cucumber-js bin |
 
 HTML Report
 -----------

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const ROUNDROBIN = 'roundrobin';
 const UNIFORM = 'uniform';
 
 const CUCUMBER_JS_PATH = process.env.CUCUMBER_JS_PATH ||
-	(IS_WINDOWS ? 'node_modules\\.bin\\cucumber-js.cmd' : './node_modules/.bin/cucumber-js');
+	(IS_WINDOWS ? 'node_modules\\.bin\\cucumber-js.cmd' : 'node_modules/.bin/cucumber-js');
 const NUM_WORKERS = parseInt(process.env.CUCUMBER_PARALLEL_WORKERS, 10) || 4;
 const REPORT_DIR = process.env.CUCUMBER_PARALLEL_REPORT_DIR || 'reports';
 const DISTRIBUTION = process.env.CUCUMBER_PARALLEL_DISTRIBUTION === UNIFORM ? UNIFORM : ROUNDROBIN;

--- a/index.js
+++ b/index.js
@@ -9,12 +9,15 @@ const path = require('path');
 
 const {getWorkerJson} = require('./util');
 
+const IS_WINDOWS = process.platform === 'win32';
+
 const ROUNDROBIN = 'roundrobin';
 const UNIFORM = 'uniform';
 
-const CUCUMBER_JS_PATH = process.env.CUCUMBER_JS_PATH || './node_modules/.bin/cucumber-js';
+const CUCUMBER_JS_PATH = process.env.CUCUMBER_JS_PATH ||
+	(IS_WINDOWS ? 'node_modules\\.bin\\cucumber-js.cmd' : './node_modules/.bin/cucumber-js');
 const NUM_WORKERS = parseInt(process.env.CUCUMBER_PARALLEL_WORKERS, 10) || 4;
-const REPORT_DIR = process.env.CUCUMBER_PARALLEL_REPORT_DIR || './reports';
+const REPORT_DIR = process.env.CUCUMBER_PARALLEL_REPORT_DIR || 'reports';
 const DISTRIBUTION = process.env.CUCUMBER_PARALLEL_DISTRIBUTION === UNIFORM ? UNIFORM : ROUNDROBIN;
 
 const mkdir = Promise.promisify(fs.mkdir);

--- a/index.js
+++ b/index.js
@@ -143,9 +143,7 @@ function spawnWorker(features, argv, outfile) {
 			...argv,
 			'--format', `json:${outfile}`,
 			...features
-		], {
-			shell: true
-		});
+		]);
 		let stderrBuffer = '';
 		let stdoutBuffer = '';
 		worker.stderr.on('data', (data) => {


### PR DESCRIPTION
Removing the shell option when spawning workers so we don't have to deal with `cmd`. Pointing to the Windows bin for the default worker executable, if we're on Windows.

@tomatobrown @AlexSun98

Close #8 